### PR TITLE
Project Indexは使用してないため削除

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -33,12 +33,6 @@ class ProjectsController < ApplicationController
   include ActionController::Serialization
   before_action :set_project, only: [:show]
 
-  def index
-    @projects = Project.all
-
-    render json: @projects
-  end
-
   def search
     @project = Search::Project.new(search_params)
     @projects = @project.matches

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :popular_projects, only: [:index]
   resources :popular_libraries, only: [:index]
 
-  resources :projects, only:[:index, :show] do
+  resources :projects, only:[:show] do
     collection do
       get 'search'
     end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -32,10 +32,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Projects', type: :request do
-  describe 'GET /projects' do
-    it 'works! (now write some real specs)' do
-      get projects_path
-      expect(response).to have_http_status(200)
-    end
-  end
+  #describe 'GET /projects' do
+  #  it 'works! (now write some real specs)' do
+  #    get projects_path
+  #    expect(response).to have_http_status(200)
+  #  end
+  #end
 end


### PR DESCRIPTION
クライアント側で [ /project/:id ] で検索するとき id がない場合、indexが呼ばれ 大量データでサーバーサイドが止まるため安全のためindexを削除
